### PR TITLE
to pass data.table 1.14.2

### DIFF
--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,4 +1,31 @@
 library(testthat)
 library(NMdata)
 
+expect_equal_to_reference = function(x,y,...) {
+  # wrapper to handle data.table v1.14.2 whose as.data.frame() now removes indices; news item 27
+  # this will pass data.table before and after 1.14.2, and without needing to rewrite all the
+  # RDS reference files which contain the index on the data.frame
+  
+  if (is.list(x) && is.data.frame(x$input.colnames)) {
+    y = readRDS(y)
+    attr(x$input.colnames, "index") = NULL
+    attr(y$input.colnames, "index") = NULL
+    testthat::expect_equal(x,y,...)
+  } else if (inherits(x,"NMdata")) {
+    y = readRDS(y)
+    attr(attr(x,"NMdata")$input.colnames, "index") = NULL
+    attr(attr(y,"NMdata")$input.colnames, "index") = NULL
+    attr(attr(x,"NMdata")$tables, "index") = NULL
+    attr(attr(y,"NMdata")$tables, "index") = NULL
+    testthat::expect_equal(x,y,...)
+  } else if (is.data.frame(x) && !inherits(x,"data.table")) {
+    y = readRDS(y)
+    attr(x, "index") = NULL
+    attr(y, "index") = NULL
+    testthat::expect_equal(x,y,...)
+  } else {
+    testthat::expect_equal_to_reference(x,y,...)
+  }
+}
+
 test_check("NMdata")


### PR DESCRIPTION
Hi Philip,

In data.table dev there is a recent news item :

![image](https://user-images.githubusercontent.com/2779998/127072977-5bed4c8c-2218-41c7-b438-9e0b6941219d.png)

Unfortunately this breaks NMdata's comparison tests, https://github.com/Rdatatable/data.table/issues/5075. Many of the RDS reference files contain `data.frame`s that have the index attribute from `data.table`. There are 65 RDS and some of the `data.frame` are inside attributes of the NMdata class. So rather than rewrite multiple RDS files, or modify a lot of tests to ignore the index attribute, I went for the approach in this PR to ignore the index attribute in one place. This also has the advantage that NMdata will continue to pass checks using older versions of data.table too.

I've checked this PR passes data.table v1.14.0 as on CRAN, and v1.14.1 (dev) which will be released as 1.14.2.

Thanks, Matt